### PR TITLE
feat: fix gradle cache bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ jobs:
       - name: JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
       - run: npm i -g @stoplight/spectral-cli
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.9.22"
-    kotlin("plugin.serialization") version "1.9.22"
-    id("com.gradle.plugin-publish") version "1.2.1"
+    kotlin("jvm") version "2.1.21"
+    kotlin("plugin.serialization") version "2.1.21"
+    id("com.gradle.plugin-publish") version "2.0.0"
     id("fr.brouillard.oss.gradle.jgitver") version "0.9.1"
     id("com.diffplug.spotless") version "6.25.0"
 }
@@ -11,12 +11,12 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 }
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/github/michaelnestler/spectral/gradle/tasks/SpectralDownloadTask.kt
+++ b/src/main/kotlin/io/github/michaelnestler/spectral/gradle/tasks/SpectralDownloadTask.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -39,15 +40,13 @@ abstract class SpectralDownloadTask : DefaultTask() {
     @get:OutputFile
     abstract val binary: RegularFileProperty
 
-    private val json by lazy { Json { ignoreUnknownKeys = true } }
-    private val httpClient by lazy {
-        HttpClient.newBuilder().followRedirects(NORMAL).build()
-    }
+    private val json = Json { ignoreUnknownKeys = true }
 
     init {
         outputs.upToDateWhen {
+            val client = createHttpClient()
             if (version.get() == LATEST) {
-                checkLatestUpToDate()
+                checkLatestUpToDate(client)
             } else {
                 checkVersionMatches()
             }
@@ -56,14 +55,15 @@ abstract class SpectralDownloadTask : DefaultTask() {
 
     @TaskAction
     fun downloadSpectral() {
+        val client = createHttpClient()
         try {
-            val release = if (version.get() == LATEST) latestVersion() else fetchRelease(version.get())
+            val release = if (version.get() == LATEST) latestVersion(client) else fetchRelease(client, version.get())
             println("Downloading release ${release.name}")
             val downloadUrl =
                 release.assets.find { matchesOsAndArchitecture(it) }?.browser_download_url
                     ?: throw IllegalStateException("No release asset ${release.name}/${osAssetName()}/${architecture()} found")
             val downloadResponse =
-                httpClient.send(
+                client.send(
                     HttpRequest.newBuilder(URI.create(downloadUrl)).build(),
                     BodyHandlers.ofFile(binary.get().asFile.toPath()),
                 )
@@ -73,7 +73,7 @@ abstract class SpectralDownloadTask : DefaultTask() {
             }
             println("Downloaded binary to ${downloadResponse.body()}")
         } catch (exception: Exception) {
-            exception.printStackTrace()
+            throw GradleException("Failed to download Spectral", exception)
         }
     }
 
@@ -97,10 +97,10 @@ abstract class SpectralDownloadTask : DefaultTask() {
         }
     }
 
-    private fun checkLatestUpToDate(): Boolean {
+    private fun checkLatestUpToDate(client: HttpClient): Boolean {
         println("Fetching latest version from GitHub...")
         try {
-            val releaseResponse = latestVersion()
+            val releaseResponse = latestVersion(client)
             println("Found latest version ${releaseResponse.name}")
             return checkVersionMatches(releaseResponse.name)
         } catch (exception: Exception) {
@@ -143,9 +143,9 @@ abstract class SpectralDownloadTask : DefaultTask() {
         }
     }
 
-    private fun latestVersion(): ReleaseResponse {
+    private fun latestVersion(client: HttpClient): ReleaseResponse {
         val response =
-            httpClient.send(
+            client.send(
                 HttpRequest.newBuilder(URI.create("https://api.github.com/repos/stoplightio/spectral/releases/latest"))
                     .build(),
                 BodyHandlers.ofString(),
@@ -153,9 +153,12 @@ abstract class SpectralDownloadTask : DefaultTask() {
         return json.decodeFromString(response.body())
     }
 
-    private fun fetchRelease(version: String): ReleaseResponse {
+    private fun fetchRelease(
+        client: HttpClient,
+        version: String,
+    ): ReleaseResponse {
         val response =
-            httpClient.send(
+            client.send(
                 HttpRequest.newBuilder(URI.create("https://api.github.com/repos/stoplightio/spectral/releases/tags/v${normalize(version)}"))
                     .build(),
                 BodyHandlers.ofString(),
@@ -175,6 +178,10 @@ abstract class SpectralDownloadTask : DefaultTask() {
         val output = process.inputReader().readText()
         val returnCode = process.waitFor()
         return returnCode to output
+    }
+
+    private fun createHttpClient(): HttpClient {
+        return HttpClient.newBuilder().followRedirects(NORMAL).build()
     }
 }
 


### PR DESCRIPTION
Hello, good evening!

Thank you for this awesome work in wrapping spectral into a gradle plugin!

I am using it in my company but when I try to run it with cache enabled, it fails with the following error:

```
❯ ./gradlew clean build --refresh-dependencies --no-daemon --no-build-cache
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.14/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Calculating task graph as configuration cache cannot be reused due to --refresh-dependencies

> Configure project :
WARNING: Unsupported Kotlin plugin version.
The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `2.0.21` that might work differently than in the requested version `2.2.21`.

1 problem was found storing the configuration cache.
- Task `:example-project:openapi_diff_print` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14/userguide/configuration_cache.html#config_cache:requirements:disallowed_types

See the complete report at file:///data/conventions/kotlin/build/reports/configuration-cache/2315s93ibeqy4wxiv19d0xke/cyor8wfnhs3zsxq5h7bg0sv1f/configuration-cache-report.html

[Incubating] Problems report is available at: file:///data/conventions/kotlin/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Configuration cache state could not be cached: field `value` of `kotlin.InitializedLazyImpl` bean found in field `httpClient$delegate` of task `:example-project:spectralDownload` of type `io.github.michaelnestler.spectral.gradle.tasks.SpectralDownloadTask`: error writing value of type 'jdk.internal.net.http.HttpClientFacade'
> Unable to make field final jdk.internal.net.http.HttpClientImpl jdk.internal.net.http.HttpClientFacade.impl accessible: module java.net.http does not "opens jdk.internal.net.http" to unnamed module @383a4fa6

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1m 6s
18 actionable tasks: 9 executed, 9 up-to-date
Configuration cache entry discarded with 1 problem.
```


Luckily, the fix was quite straightforward and I am sending a PR for you in case it helps :)

I am eager to help with anything to get this one forward. Thank you!